### PR TITLE
Bump version to 2.11.0 and tagging release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [2.11.0] - 2024-08-06Z
 - Updated fastlane FASTFILE
 
 ### Changed

--- a/ios-core-library.xcodeproj/ios_core_libraryTests_Info.plist
+++ b/ios-core-library.xcodeproj/ios_core_libraryTests_Info.plist
@@ -14,7 +14,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.10.2</string>
+  <string>2.11.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/ios-core-library.xcodeproj/ios_core_library_Info.plist
+++ b/ios-core-library.xcodeproj/ios_core_library_Info.plist
@@ -14,7 +14,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.10.2</string>
+  <string>2.11.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
# 📝 Description
https://jira.tools.tax.service.gov.uk/browse/HMA-6786
  
update main with release bump.
  
- [x ] Updated CHANGELOG


